### PR TITLE
Find openal build flags using pkg-config

### DIFF
--- a/Pilot_Episode/build.sh
+++ b/Pilot_Episode/build.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-additional_flags="-I/opt/homebrew/opt/openal-soft/include -L/opt/homebrew/opt/openal-soft/lib -lopenal"
+additional_flags=""
 #additional_flags="-I/opt/homebrew/opt/openal-soft/include -L/opt/homebrew/opt/openal-soft/lib -lopenal.1.23.1"
 #additional_flags="-I/opt/homebrew/opt/openal-soft/include -L/opt/homebrew/opt/openal-soft/lib /opt/homebrew/opt/openal-soft/lib/libopenal.dylib"
 
+export BUILD_PKG_CONFIG_MODULES='openal'
 
-../../lib/Core/build.sh pilot_episode $1 "${additional_flags[@]}"
+../../lib/Core/build.sh pilot_episode "$1" "${additional_flags[@]}"


### PR DESCRIPTION
Use the environment variable added in https://github.com/razterizer/Core/pull/6 to figure out compiler flags for openal using pkg-config.

I have removed all the `additional_flags`, hopefully `pkg-config` will find them even on MacOS.